### PR TITLE
Ignore codemeta.json in .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^doc$
 ^Meta$
 ^\.github$
+^codemeta\.json$


### PR DESCRIPTION
This ignores the codemeta.json file as I requested in the rOpenSci review thread